### PR TITLE
Create terraform-mfa container

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,0 +1,7 @@
+{
+    "image": "public.ecr.aws/l2m0t2f1/terraform-mfa:1.2",
+    "extensions": [
+        "eamodio.gitlens",
+        "hashicorp.terraform"
+    ]
+}

--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -1,5 +1,5 @@
 {
-    "image": "public.ecr.aws/l2m0t2f1/terraform-mfa:1.2",
+    "image": "terraform-mfa:22.202303",
     "extensions": [
         "eamodio.gitlens",
         "hashicorp.terraform"

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ override.tf.json
 
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
+
+*.secure
+*.log

--- a/containers/terraform-mfa/Dockerfile
+++ b/containers/terraform-mfa/Dockerfile
@@ -24,7 +24,7 @@ ENV LANG en_US.utf8
 RUN curl -L https://github.com/99designs/aws-vault/releases/download/v6.2.0/aws-vault-linux-amd64 -o /usr/bin/aws-vault \
 && chmod 755 /usr/bin/aws-vault
 
-ENV AWS_VAULT_BACKEND pass
+# ENV AWS_VAULT_BACKEND pass
 ENV GPG_TTY /dev/pts/0
 
 ###############################################################################

--- a/containers/terraform-mfa/Dockerfile
+++ b/containers/terraform-mfa/Dockerfile
@@ -1,0 +1,65 @@
+FROM ubuntu:22.04
+
+# タイムゾーンの設定
+ENV TZ=Asia/Tokyo
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+###############################################################################
+# root
+###############################################################################
+
+#NOTE リリース用ビルドをするときは --no-cache をつけること
+RUN apt-get update
+RUN apt-get install -y locales
+# NOTE gnupg, pass, pinentryがbrewでうまく動作しないのでaptでインストールしている
+RUN apt-get install -y gnupg pass curl unzip
+RUN apt-get install -y build-essential procps curl file git
+RUN apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev zlib1g-dev libssl-dev
+RUN apt-get clean && rm -rf /var/lib/apt/lists/*
+
+RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+ENV LANG en_US.utf8
+
+# install aws-vault
+RUN curl -L https://github.com/99designs/aws-vault/releases/download/v6.2.0/aws-vault-linux-amd64 -o /usr/bin/aws-vault \
+&& chmod 755 /usr/bin/aws-vault
+
+ENV AWS_VAULT_BACKEND pass
+ENV GPG_TTY /dev/pts/0
+
+###############################################################################
+# 一般ユーザー
+###############################################################################
+
+# NOTE ホストのファイルシステムをバインドする場合はrootにしないと書き込みができないのでコメントアウトしている。
+#      一般ユーザーを使用する場合は名前付きボリュームを使う。
+# RUN groupadd linuxbrew && useradd -m -s /bin/bash -g linuxbrew linuxbrew
+# USER linuxbrew
+# WORKDIR /home/linuxbrew
+
+# install tfenv
+RUN git clone --depth=1 https://github.com/tfutils/tfenv.git ~/.tfenv \
+&& echo 'export PATH="$HOME/.tfenv/bin:$PATH"' >> ~/.bash_profile
+
+# install brew
+# 一般ユーザーはbrewでのみでパッケージのインストールが可能。既存のパッケージもbrewがオーバーライドする。
+RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+RUN test -d ~/.linuxbrew && eval "$(~/.linuxbrew/bin/brew shellenv)" \
+; test -d /home/linuxbrew/.linuxbrew && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" \
+; test -r ~/.bash_profile && echo "eval \"\$($(brew --prefix)/bin/brew shellenv)\"" >> ~/.bash_profile \
+; echo "eval \"\$($(brew --prefix)/bin/brew shellenv)\"" >> ~/.bashrc
+
+# NOTE Nead FontはWindows, Mac側にインストールし、VSCodeの設定の`Terminal › Integrated: Font Family`で`Nerd Font`を指定してください
+RUN /home/linuxbrew/.linuxbrew/bin/brew install starship \
+&& echo 'eval "$(starship init bash)"' >> ~/.bashrc
+
+RUN /home/linuxbrew/.linuxbrew/bin/brew install pyenv \
+&& echo 'eval "$(pyenv init -)"' >> ~/.bashrc
+
+RUN /home/linuxbrew/.linuxbrew/bin/brew install nodenv \
+&& echo 'eval "$(nodenv init -)"' >> ~/.bashrc
+
+# ホームの情報はマウントしたボリュームに保存する
+VOLUME ["/root"]
+
+CMD ["bash"]

--- a/containers/terraform-mfa/Dockerfile
+++ b/containers/terraform-mfa/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:22.10
 
 # タイムゾーンの設定
 ENV TZ=Asia/Tokyo
@@ -9,12 +9,12 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 ###############################################################################
 
 #NOTE リリース用ビルドをするときは --no-cache をつけること
-RUN apt-get update
+RUN apt-get update && apt-get upgrade -y
 RUN apt-get install -y locales
 # NOTE gnupg, pass, pinentryがbrewでうまく動作しないのでaptでインストールしている
 RUN apt-get install -y gnupg pass curl unzip
 RUN apt-get install -y build-essential procps curl file git
-RUN apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev zlib1g-dev libssl-dev
+# RUN apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev libffi-dev liblzma-dev zlib1g-dev libssl-dev
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
@@ -43,23 +43,23 @@ RUN git clone --depth=1 https://github.com/tfutils/tfenv.git ~/.tfenv \
 
 # install brew
 # 一般ユーザーはbrewでのみでパッケージのインストールが可能。既存のパッケージもbrewがオーバーライドする。
-RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-RUN test -d ~/.linuxbrew && eval "$(~/.linuxbrew/bin/brew shellenv)" \
-; test -d /home/linuxbrew/.linuxbrew && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" \
-; test -r ~/.bash_profile && echo "eval \"\$($(brew --prefix)/bin/brew shellenv)\"" >> ~/.bash_profile \
-; echo "eval \"\$($(brew --prefix)/bin/brew shellenv)\"" >> ~/.bashrc
+# RUN /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+# RUN test -d ~/.linuxbrew && eval "$(~/.linuxbrew/bin/brew shellenv)" \
+# ; test -d /home/linuxbrew/.linuxbrew && eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)" \
+# ; test -r ~/.bash_profile && echo "eval \"\$($(brew --prefix)/bin/brew shellenv)\"" >> ~/.bash_profile \
+# ; echo "eval \"\$($(brew --prefix)/bin/brew shellenv)\"" >> ~/.bashrc
 
 # NOTE Nead FontはWindows, Mac側にインストールし、VSCodeの設定の`Terminal › Integrated: Font Family`で`Nerd Font`を指定してください
-RUN /home/linuxbrew/.linuxbrew/bin/brew install starship \
-&& echo 'eval "$(starship init bash)"' >> ~/.bashrc
+# RUN /home/linuxbrew/.linuxbrew/bin/brew install starship \
+# && echo 'eval "$(starship init bash)"' >> ~/.bashrc
 
-RUN /home/linuxbrew/.linuxbrew/bin/brew install pyenv \
-&& echo 'eval "$(pyenv init -)"' >> ~/.bashrc
+# RUN /home/linuxbrew/.linuxbrew/bin/brew install pyenv \
+# && echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 
-RUN /home/linuxbrew/.linuxbrew/bin/brew install nodenv \
-&& echo 'eval "$(nodenv init -)"' >> ~/.bashrc
+# RUN /home/linuxbrew/.linuxbrew/bin/brew install nodenv \
+# && echo 'eval "$(nodenv init -)"' >> ~/.bashrc
 
 # ホームの情報はマウントしたボリュームに保存する
-VOLUME ["/root"]
+# VOLUME ["/root"]
 
 CMD ["bash"]

--- a/containers/terraform-mfa/README.md
+++ b/containers/terraform-mfa/README.md
@@ -1,0 +1,56 @@
+# terraform-mfa
+
+AWSの多段階認証に対応したTerraformの実行環境を提供するコンテナです。
+
+## Terraformを使ってみよう
+
+### AWS側に必要な設定
+
+AWS側に管理者権限を持つ terraform ユーザーを作成します。
+Terraformはこのユーザーを使ってクラウドサービスの構築／廃棄を行います。
+
+1. ルートなど、管理者権限のあるアカウントでAWS管理コンソールにログインし、IAMを開きます。
+1. ユーザー`terraform`を作成します。
+    * このユーザーでAWS管理コンソールで操作できないよう「AWS 認証情報タイプを選択」の「アクセスキー - プログラムによるアクセス」をチェックを入れておきます。
+1. ユーザー`terraform`のアクセス権限に`AdministratorAccess`を割り当てます。
+1. アクセスキーを発行します。
+1. 多段階認証を利用するために、MFAデバイスの割り当てを行います。
+
+### クライアント側に必要な設定
+
+1. VSCodeを開き、新しいプロジェクト（フォルダー）を開きます。
+1. プロジェクトルートに `.devcontainer.json` ファイルを以下の内容で作成します。
+    ```
+    {
+        "image": "public.ecr.aws/l2m0t2f1/terraform-mfa:1.2",
+        # 次の1行を記述すると、アクセスキーやシークレットキーはDockerの名前付きボリューム "terraform_credentials" に保存されます。
+        # 認証情報を複数のコンテナで共有したいときはこの行を追加します
+        "mounts": ["source=terraform_credentials,target=/root"],
+        "extensions": [
+            "eamodio.gitlens",
+            "hashicorp.terraform"
+        ]
+    }
+    ```
+1. VSCodeのコマンドパレットから、`Remote-Containers: Open Folder in Container...` を実行し、`.devcontainer.json`が保存されているフォルダーを開きます。
+1. VSCodeでターミナルを開き、以下のコマンドを順に実行します。
+    * `gpg --gen-key`を実行し鍵を生成します。より強力な暗号化を使用する場合は `gpg --full-generate-key`を実行します。
+    * `pass init {gpgコマンドで入力したメールアドレス}` を実行し、パスワードストアを初期化します。
+    * `aws-vault add {プロファイル名}` を実行し、AWSのアクセスキーとシークレットキーを入力します。
+    * `~/.aws/config`ファイルを以下の内容で作成します。
+        ```
+        [default]
+        region=ap-northeast-1
+        output=json
+
+        [profile {プロファイル名}]
+        mfa_serial=arn:aws:iam::{AWSのアカウントID}:mfa/terraform
+        ```
+    * `aws-vault exec {プロファイル名} --no-session -- env | grep AWS_`を実行し、AWSアクセスキーとシークレットキーが正しく設定されていることを確認します。
+    * `aws-vault exec {プロファイル名} -- terraform init`を実行します。
+    * `pass` を実行し、以下のような出力が得られることを確認します。     
+        ```
+        Password Store
+        |-- {プロファイル名}
+        `-- sts.GetSessionToken,ZGV2b3Bz,,1644128599
+        ```


### PR DESCRIPTION
プライベートリポジトリからのマージです。

1. ローカルでの動作確認中に terraform-mfa コンテナが正常に動かない現象があり、調査しました。
    - `gpg --gen-key` がエラーになる。
    - VSCode 1.75 以降で発生する (X11 & Wayland Forwardingが影響している様子）
1. gpgが複数バージョン存在するとうまく動作しなくなる可能性があるので、brewを一旦取り除きました。

```
Change (N)ame, (E)mail, or (O)kay/(Q)uit? O
We need to generate a lot of random bytes. It is a good idea to perform
some other action (type on the keyboard, move the mouse, utilize the
disks) during the prime generation; this gives the random number
generator a better chance to gain enough entropy.
gpg: WARNING: server 'gpg-agent' is older than us (2.2.19 < 2.2.20)
gpg: Note: Outdated servers may lack important security fixes.
gpg: Note: Use the command "gpgconf --kill all" to restart them.
gpg: agent_genkey failed: Forbidden
Key generation failed: Forbidden
```